### PR TITLE
Redirect back to the app when signing out

### DIFF
--- a/app/controllers/kracken/sessions_controller.rb
+++ b/app/controllers/kracken/sessions_controller.rb
@@ -9,6 +9,7 @@ module Kracken
 
     def destroy
       reset_session
+      flash[:notice] = "Signed out successfully."
       redirect_to "#{provider_url}/users/sign_out#{signout_redirect_query}"
     end
 


### PR DESCRIPTION
This will set a `redirect_to` url param that the account server can use to redirect the user back to the original app.

Hopefully this will help mitigate any confusion around juggling accounts between the servers.
