### PR TITLE
Automatically update user from oauth server

### DIFF
--- a/app/controllers/kracken/sessions_controller.rb
+++ b/app/controllers/kracken/sessions_controller.rb
@@ -9,6 +9,7 @@ module Kracken
       @user = user_class.find_or_create_from_auth_hash(auth_hash)
       current_user = @user
       session[:user_id] = @user.id
+      session[:user_cache_key] = cookies[:_radius_user_cache_key]
       redirect_to return_to_path
     end
 

--- a/lib/kracken/version.rb
+++ b/lib/kracken/version.rb
@@ -1,3 +1,3 @@
 module Kracken
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/spec/kracken/controllers/authenticatable_spec.rb
+++ b/spec/kracken/controllers/authenticatable_spec.rb
@@ -90,6 +90,31 @@ module Kracken
 
           expect(User).to have_received(:find)
         end
+
+
+        context "user cache cookie" do
+          it "redirects when the cache cookie is different than the session" do
+            allow(controller).to receive(:request).and_return(double(format: nil, fullpath: nil))
+            allow(controller).to receive(:cookies).and_return({_radius_user_cache_key: "123"})
+            allow(controller).to receive(:redirect_to)
+
+            controller.authenticate_user!
+
+            expect(controller).to have_received(:redirect_to).with("/")
+          end
+
+          it "does not redirect when the cache cookie matches the session" do
+            allow(controller).to receive(:request).and_return(double(format: nil, fullpath: nil))
+            allow(controller).to receive(:redirect_to)
+
+            controller.cookies[:_radius_user_cache_key] = "123"
+            controller.session[:user_cache_key] = "123"
+
+            controller.authenticate_user!
+
+            expect(controller).to_not have_received(:redirect_to)
+          end
+        end
       end
 
     end

--- a/spec/support/base_controller_double.rb
+++ b/spec/support/base_controller_double.rb
@@ -1,9 +1,10 @@
 module Kracken
   class BaseControllerDouble
-    attr_accessor :session
+    attr_accessor :session, :cookies
 
     def initialize
       @session = {}
+      @cookies = {}
     end
 
     def self.helper_method(*) ; end


### PR DESCRIPTION
We needed a way to update the user information on kracken and automatically update all the client apps. Instead of pushing changes out to them we added a cookie that will act as an indicator that the user is stale and they need to be updated.

The refresh is accomplished by redirecting to the normal oauth flow which will simply redirect the back if they are already signed in (or ask for a user/pass if they are not).

The basic steps are:

 - Check for the `_radius_user_cache_key` tld cookie
 - Compare it to the `user_cache_key` in the session
 - If they don't match, redirect them to the oauth provider and delete the cookie