### PR TITLE
Cache auth tokens

### DIFF
--- a/lib/kracken/controllers/token_authenticatable.rb
+++ b/lib/kracken/controllers/token_authenticatable.rb
@@ -11,8 +11,6 @@ module Kracken
           before_action :authenticate_user_with_token!
           helper_method :current_user
         end
-
-
       end
 
       attr_reader :current_user
@@ -23,7 +21,7 @@ module Kracken
         raise TokenUnauthorized, "Invalid Credentials"
       end
 
-      private
+    private
 
       # `authenticate_or_request_with_http_token` is a nice Rails helper:
       # http://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token/ControllerMethods.html#method-i-authenticate_or_request_with_http_token

--- a/lib/kracken/rspec.rb
+++ b/lib/kracken/rspec.rb
@@ -47,6 +47,7 @@ module Kracken
         Kracken::SpecHelper.current_user
       end
 
+      alias_method :__original_auth__, :authenticate_user_with_token!
       def authenticate_user_with_token!
         if current_user
           @_auth_info = {
@@ -54,7 +55,7 @@ module Kracken
             team_ids: current_user.team_ids,
           }
         else
-          super
+          __original_auth__
         end
       end
     end

--- a/lib/kracken/rspec.rb
+++ b/lib/kracken/rspec.rb
@@ -46,6 +46,17 @@ module Kracken
       def current_user
         Kracken::SpecHelper.current_user
       end
+
+      def authenticate_user_with_token!
+        if current_user
+          @_auth_info = {
+            id: current_user.id,
+            team_ids: current_user.team_ids,
+          }
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -22,4 +22,10 @@ class User
   def uid
     @hash["uid"]
   end
+
+  def team_ids
+    @hash["info"] ||= {}
+    @hash["info"]["teams"] ||= []
+    @hash["info"]["teams"].map { |t| t["uid"] }
+  end
 end

--- a/spec/kracken/controllers/token_authenticatable_spec.rb
+++ b/spec/kracken/controllers/token_authenticatable_spec.rb
@@ -230,19 +230,6 @@ module Kracken
           a_controller.authenticate_user_with_token!
           expect(a_controller.current_user).to be a_user
         end
-
-        # TODO: Delete this test after implementation is complete
-        # This is only to ensure we maintain general backwards compatibility
-        it "authenticates the current user via the token" do
-          controller = TokenAuthController.new
-          controller.request.env = {
-            'HTTP_AUTHORIZATION' => 'Token token="any token"'
-          }
-
-          expect {
-            controller.authenticate_user_with_token!
-          }.to change { controller.current_user }.from(nil).to(a_user)
-        end
       end
     end
   end

--- a/spec/kracken/controllers/token_authenticatable_spec.rb
+++ b/spec/kracken/controllers/token_authenticatable_spec.rb
@@ -1,0 +1,67 @@
+require "support/base_controller_double"
+
+module Kracken
+  class TokenAuthController < BaseControllerDouble
+    include Kracken::Controllers::TokenAuthenticatable
+    public :authenticate_user_with_token!
+    public :current_user
+
+    def authenticate_or_request_with_http_token(realm = nil)
+      /\AToken token="(?<token>.*)"\z/ =~ request.env['HTTP_AUTHORIZATION']
+      yield token if block_given?
+    end
+  end
+
+  RSpec.describe Controllers::TokenAuthenticatable do
+    describe "authenticating via a token" do
+      before do
+        allow(Authenticator).to receive(:user_with_token)
+      end
+
+      it "munges the request headers to support parameterized tokens" do
+        controller = TokenAuthController.new
+        controller.request.env = {
+          'HTTP_AUTHORIZATION' => 'Token token="header token"'
+        }
+        controller.params = { token: "param token" }
+
+        expect {
+          controller.authenticate_user_with_token!
+        }.to change {
+          controller.request.env
+        }.from(
+          'HTTP_AUTHORIZATION' => 'Token token="header token"'
+        ).to(
+          'HTTP_AUTHORIZATION' => 'Token token="param token"'
+        )
+      end
+
+      it "leaves the request header unchange when with no parameterized token" do
+        controller = TokenAuthController.new
+        controller.request.env = {
+          'HTTP_AUTHORIZATION' => 'Token token="any token"'
+        }
+
+        expect {
+          controller.authenticate_user_with_token!
+        }.not_to change { controller.request.env }.from(
+          'HTTP_AUTHORIZATION' => 'Token token="any token"'
+        )
+      end
+
+      it "authenticates the current user via the token" do
+        a_user = instance_double(User)
+        allow(Authenticator).to receive(:user_with_token).with("any token")
+                                                         .and_return(a_user)
+        controller = TokenAuthController.new
+        controller.request.env = {
+          'HTTP_AUTHORIZATION' => 'Token token="any token"'
+        }
+
+        expect {
+          controller.authenticate_user_with_token!
+        }.to change { controller.current_user }.from(nil).to(a_user)
+      end
+    end
+  end
+end

--- a/spec/kracken/controllers/token_authenticatable_spec.rb
+++ b/spec/kracken/controllers/token_authenticatable_spec.rb
@@ -21,20 +21,21 @@ module Kracken
 
   RSpec.describe Controllers::TokenAuthenticatable do
     describe "authenticating via a token", :using_cache do
+      subject(:a_controller) { TokenAuthController.new }
+
       shared_examples "the authorization request headers" do |token_helper|
         let(:expected_token) { public_send token_helper }
 
         specify "are munged to include a provided parameterized token" do
-          controller = TokenAuthController.new
-          controller.request.env = {
+          a_controller.request.env = {
             'HTTP_AUTHORIZATION' => 'Token token="header token"'
           }
-          controller.params = { token: expected_token }
+          a_controller.params = { token: expected_token }
 
           expect {
-            controller.authenticate_user_with_token!
+            a_controller.authenticate_user_with_token!
           }.to change {
-            controller.request.env
+            a_controller.request.env
           }.from(
             'HTTP_AUTHORIZATION' => 'Token token="header token"'
           ).to(
@@ -43,48 +44,117 @@ module Kracken
         end
 
         specify "are not modified when no parameterized token provided" do
-          controller = TokenAuthController.new
-          controller.request.env = {
+          a_controller.request.env = {
             'HTTP_AUTHORIZATION' => "Token token=\"#{expected_token}\""
           }
 
           expect {
-            controller.authenticate_user_with_token!
-          }.not_to change { controller.request.env }.from(
+            a_controller.authenticate_user_with_token!
+          }.not_to change { a_controller.request.env }.from(
             'HTTP_AUTHORIZATION' => "Token token=\"#{expected_token}\""
           )
         end
       end
 
       context "on a cache hit" do
+        let(:auth_info) {
+          {
+            id: :any_id,
+            team_ids: [:some, :team, :ids],
+          }
+        }
         let(:cached_token) { "any token" }
         let(:cache_key) { "auth/token/any token" }
 
         before do
-          Rails.cache.write(cache_key, "auth info")
+          a_controller.request.env = {
+            'HTTP_AUTHORIZATION' => "Token token=\"#{cached_token}\""
+          }
+
+          Rails.cache.write cache_key, auth_info
+          stub_const "Kracken::Authenticator", spy("Kracken::Authenticator")
         end
 
         include_examples "the authorization request headers", :cached_token
 
-        it "uses the exising cache to bypass the authentication process"
-        it "returns the auth info"
-        it "exposes the auth info via the `current_` helpers"
-        it "lazy loads the current user"
+        it "uses the exising cache to bypass the authentication process" do
+          a_controller.authenticate_user_with_token!
+          expect(Authenticator).not_to have_received(:user_with_token)
+        end
+
+        it "returns the auth info" do
+          expect(a_controller.authenticate_user_with_token!).to eq(
+            id: :any_id,
+            team_ids: [:some, :team, :ids],
+          ).and be_frozen
+        end
+
+        it "exposes the auth info via the `current_` helpers", :aggregate_failures do
+          expect {
+            a_controller.authenticate_user_with_token!
+          }.to(
+            change { a_controller.current_auth_info }.from({}).to(auth_info)
+            .and change { a_controller.current_user_id }.from(nil).to(:any_id)
+            .and change { a_controller.current_team_ids }.from(nil).to(
+              [:some, :team, :ids]
+            )
+          )
+
+          expect(a_controller.current_auth_info).to be_frozen
+          expect(a_controller.current_team_ids).to be_frozen
+        end
+
+        it "lazy loads the current user" do
+          begin
+            # Ensure we cannot lookup a user - doing so would raise an error
+            org_user_class = Kracken.config.user_class
+            user_class = double("AnyUserClass")
+            Kracken.config.user_class = user_class
+
+            # Action under test
+            a_controller.authenticate_user_with_token!
+
+            # Make sure we perform the lookup as expected now
+            expect(user_class).to receive(:find).with(:any_id).and_return(:user)
+
+            expect(a_controller.current_user).to be :user
+          ensure
+            Kracken.config.user_class = org_user_class
+          end
+        end
       end
 
       context "on a cache miss with an invalid token" do
         let(:invalid_token) { "any token" }
 
         before do
+          a_controller.request.env = {
+            'HTTP_AUTHORIZATION' => "Token token=\"#{invalid_token}\""
+          }
+
           allow(Authenticator).to receive(:user_with_token).with(invalid_token)
                                                            .and_return(nil)
         end
 
         include_examples "the authorization request headers", :invalid_token
 
-        it "follows the token authentication process"
-        it "returns nil"
-        it "doesn't cache invalid tokens"
+        it "follows the token authentication process" do
+          a_controller.authenticate_user_with_token!
+          expect(Authenticator).to have_received(:user_with_token)
+            .with(invalid_token)
+        end
+
+        it "returns nil" do
+          expect(a_controller.authenticate_user_with_token!).to be nil
+        end
+
+        it "doesn't cache invalid tokens" do
+          expect {
+            a_controller.authenticate_user_with_token!
+          }.not_to change {
+            Rails.cache.exist?("auth/token/#{invalid_token}")
+          }.from false
+        end
       end
 
       context "on a cache miss with a valid token" do
@@ -96,20 +166,73 @@ module Kracken
         let(:valid_token) { "any token" }
 
         before do
+          a_controller.request.env = {
+            'HTTP_AUTHORIZATION' => "Token token=\"#{valid_token}\""
+          }
+
           allow(Authenticator).to receive(:user_with_token).with(valid_token)
                                                            .and_return(a_user)
         end
 
         include_examples "the authorization request headers", :valid_token
 
-        it "follows the token authentication process"
-        it "returns the auth info"
-        it "exposes the auth info via the `current_` helpers"
-        it "sets the auth info as the cache value"
-        it "sets the cache expiration to one minute by default"
-        it "sets the cache expiration to the environment setting `KRACKEN_TOKEN_TTL` when available"
-        it "eager loads the current user"
+        it "follows the token authentication process" do
+          a_controller.authenticate_user_with_token!
+          expect(Authenticator).to have_received(:user_with_token)
+            .with(valid_token)
+        end
 
+        it "returns the auth info in a frozen state" do
+          expect(a_controller.authenticate_user_with_token!).to eq(
+            id: :any_id,
+            team_ids: [:some, :team, :ids],
+          ).and be_frozen
+        end
+
+        it "exposes the auth info via the `current_` helpers", :aggregate_failures do
+          expect {
+            a_controller.authenticate_user_with_token!
+          }.to(
+            change { a_controller.current_auth_info }.from({}).to(
+              id: :any_id,
+              team_ids: [:some, :team, :ids],
+            )
+            .and change { a_controller.current_user_id }.from(nil).to(:any_id)
+            .and change { a_controller.current_team_ids }.from(nil).to(
+              [:some, :team, :ids]
+            )
+          )
+
+          expect(a_controller.current_auth_info).to be_frozen
+          expect(a_controller.current_team_ids).to be_frozen
+        end
+
+        it "sets the auth info as the cache value" do
+          expect {
+            a_controller.authenticate_user_with_token!
+          }.to change { Rails.cache.read("auth/token/any token") }.from(nil).to(
+            id: :any_id,
+            team_ids: [:some, :team, :ids],
+          )
+        end
+
+        it "sets the cache expiration to one minute by default" do
+          expect(Rails.cache).to receive(:write).with(
+            "auth/token/any token",
+            anything,
+            include(expires_in: 1.minute),
+          )
+          a_controller.authenticate_user_with_token!
+        end
+
+        it "eager loads the current user" do
+          expect(Kracken.config.user_class).not_to receive(:find)
+          a_controller.authenticate_user_with_token!
+          expect(a_controller.current_user).to be a_user
+        end
+
+        # TODO: Delete this test after implementation is complete
+        # This is only to ensure we maintain general backwards compatibility
         it "authenticates the current user via the token" do
           controller = TokenAuthController.new
           controller.request.env = {

--- a/spec/kracken/controllers/token_authenticatable_spec.rb
+++ b/spec/kracken/controllers/token_authenticatable_spec.rb
@@ -4,7 +4,13 @@ module Kracken
   class TokenAuthController < BaseControllerDouble
     include Kracken::Controllers::TokenAuthenticatable
     public :authenticate_user_with_token!
-    public :current_user
+    # The module includes things as private so that they are not accidentally
+    # exposed as controller routes. However, we really treat some of them as the
+    # "public" API for the module:
+    public :current_auth_info,
+           :current_team_ids,
+           :current_user,
+           :current_user_id
 
     def authenticate_or_request_with_http_token(realm = nil)
       /\AToken token="(?<token>.*)"\z/ =~ request.env['HTTP_AUTHORIZATION']
@@ -14,10 +20,35 @@ module Kracken
 
   RSpec.describe Controllers::TokenAuthenticatable do
     describe "authenticating via a token" do
+      context "on a cache hit" do
+        it "munges the request headers to support parameterized tokens"
+        it "leaves the request header unchange when with no parameterized token"
+        it "uses the exising cache to bypass the authentication process"
+        it "returns the auth info"
+        it "exposes the auth info via the `current_` helpers"
+        it "lazy loads the current user"
+      end
+
+      context "on a cache miss with an invalid token" do
+        it "munges the request headers to support parameterized tokens"
+        it "leaves the request header unchange when with no parameterized token"
+        it "follows the token authentication process"
+        it "returns nil"
+        it "doesn't cache invalid tokens"
+      end
+
       context "on a cache miss with a valid token" do
         before do
           allow(Authenticator).to receive(:user_with_token)
         end
+
+        it "follows the token authentication process"
+        it "returns the auth info"
+        it "exposes the auth info via the `current_` helpers"
+        it "sets the auth info as the cache value"
+        it "sets the cache expiration to one minute by default"
+        it "sets the cache expiration to the environment setting `KRACKEN_TOKEN_TTL` when available"
+        it "eager loads the current user"
 
         it "munges the request headers to support parameterized tokens" do
           controller = TokenAuthController.new

--- a/spec/kracken/controllers/token_authenticatable_spec.rb
+++ b/spec/kracken/controllers/token_authenticatable_spec.rb
@@ -14,53 +14,55 @@ module Kracken
 
   RSpec.describe Controllers::TokenAuthenticatable do
     describe "authenticating via a token" do
-      before do
-        allow(Authenticator).to receive(:user_with_token)
-      end
+      context "on a cache miss with a valid token" do
+        before do
+          allow(Authenticator).to receive(:user_with_token)
+        end
 
-      it "munges the request headers to support parameterized tokens" do
-        controller = TokenAuthController.new
-        controller.request.env = {
-          'HTTP_AUTHORIZATION' => 'Token token="header token"'
-        }
-        controller.params = { token: "param token" }
+        it "munges the request headers to support parameterized tokens" do
+          controller = TokenAuthController.new
+          controller.request.env = {
+            'HTTP_AUTHORIZATION' => 'Token token="header token"'
+          }
+          controller.params = { token: "param token" }
 
-        expect {
-          controller.authenticate_user_with_token!
-        }.to change {
-          controller.request.env
-        }.from(
-          'HTTP_AUTHORIZATION' => 'Token token="header token"'
-        ).to(
-          'HTTP_AUTHORIZATION' => 'Token token="param token"'
-        )
-      end
+          expect {
+            controller.authenticate_user_with_token!
+          }.to change {
+            controller.request.env
+          }.from(
+            'HTTP_AUTHORIZATION' => 'Token token="header token"'
+          ).to(
+            'HTTP_AUTHORIZATION' => 'Token token="param token"'
+          )
+        end
 
-      it "leaves the request header unchange when with no parameterized token" do
-        controller = TokenAuthController.new
-        controller.request.env = {
-          'HTTP_AUTHORIZATION' => 'Token token="any token"'
-        }
+        it "leaves the request header unchange when with no parameterized token" do
+          controller = TokenAuthController.new
+          controller.request.env = {
+            'HTTP_AUTHORIZATION' => 'Token token="any token"'
+          }
 
-        expect {
-          controller.authenticate_user_with_token!
-        }.not_to change { controller.request.env }.from(
-          'HTTP_AUTHORIZATION' => 'Token token="any token"'
-        )
-      end
+          expect {
+            controller.authenticate_user_with_token!
+          }.not_to change { controller.request.env }.from(
+            'HTTP_AUTHORIZATION' => 'Token token="any token"'
+          )
+        end
 
-      it "authenticates the current user via the token" do
-        a_user = instance_double(User)
-        allow(Authenticator).to receive(:user_with_token).with("any token")
-                                                         .and_return(a_user)
-        controller = TokenAuthController.new
-        controller.request.env = {
-          'HTTP_AUTHORIZATION' => 'Token token="any token"'
-        }
+        it "authenticates the current user via the token" do
+          a_user = instance_double(User)
+          allow(Authenticator).to receive(:user_with_token).with("any token")
+                                                           .and_return(a_user)
+          controller = TokenAuthController.new
+          controller.request.env = {
+            'HTTP_AUTHORIZATION' => 'Token token="any token"'
+          }
 
-        expect {
-          controller.authenticate_user_with_token!
-        }.to change { controller.current_user }.from(nil).to(a_user)
+          expect {
+            controller.authenticate_user_with_token!
+          }.to change { controller.current_user }.from(nil).to(a_user)
+        end
       end
     end
   end

--- a/spec/support/base_controller_double.rb
+++ b/spec/support/base_controller_double.rb
@@ -1,10 +1,14 @@
 module Kracken
   class BaseControllerDouble
-    attr_accessor :session, :cookies
+    Request = Struct.new(:env)
+
+    attr_accessor :session, :cookies, :request, :params
 
     def initialize
       @session = {}
       @cookies = {}
+      @request = Request.new({})
+      @params = {}
     end
 
     def self.helper_method(*) ; end

--- a/spec/support/using_cache.rb
+++ b/spec/support/using_cache.rb
@@ -1,0 +1,14 @@
+RSpec.shared_context "using Rails cache", :using_cache do
+  before(:context) do
+    @org_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache.lookup_store(:memory_store)
+  end
+
+  after(:context) do
+    Rails.cache = @org_cache
+  end
+
+  before do
+    Rails.cache.clear
+  end
+end


### PR DESCRIPTION
This adds the necessary logic to deal with caching auth tokens. As this is intended to be a Rails plugin we are leveraging the `Rails.cache` instead of injecting it. We already directly utilize the Rails cache in other parts of the code so this is consistent.

We store the key as the auth token and the value as a hash containing the authenticated user and team ids. This will allow clients to by-pass the expensive network call while still being able to resolve the critical information about user and team related ids. This could also potentially save on a potential DB lookup if the endpoints using this no longer need to perform the full user and/or team lookups and instance creations.

However, we still provide the common `current_user` helper as it is likely many existing endpoints still rely on it. But since we are mainly caching ids this helper is lazy loaded for those endpoints which do not require the user lookup and instantiation. Since we are now caching the team ids as well, we expose an additional helper to access them. For symmetry, we expose a helper for the user id.

This is also the first step in supporting team level tokens. With this hash format, such a token would simply have a `nil` user id and a single team id (still in an array).

Lastly, we need to be aware that different caching strategies may treat hashes differently. Mainly, an in-memory cache has some odd quirks. The in-memory cache returns **the same hash object** (the object ids match) when you read it. However, if the hash was frozen before being cached, when it is read it will **not** be frozen. And since reading the cache gives a new pointer to the same object (just with different frozen state) it can be mutated. Resulting in additional reads seeing the modified state.

To prevent this, and encourage clients to be defensive, we actively re-freeze the cache when we read it. This also must include freezing the internal team id array. On a cache miss, this means we also need to be sure we freeze it before setting our internal state.

In the interest of reconfigurability, without needing to make code deploys, we read the cache lifetime from the environment. Since these are meant to be API auth tokens, which tend to have relatively long lifetimes, but are still sensitive enough to that we may need to kill them relatively quickly, we default to a shorter lifetime: 1 minutes. This was arbitrarily chosen and not based on any usage patterns.

Since this gem may be used on a variety of different servers (i.e. threaded and multi-process) we need to be aware of potential dog pile effects. To try to allow for faster network requests to handle the cache we keep the `race_condition_ttl` to the minimum: 1 second. From what we've seen in the vast majority of cases this will be more than enough time for any request to return.

We are not caching invalid tokens. The problem here is malicious attack vectors. The API endpoints are vulnerable to a both brute force and DOS attack by sending lots of requests with invalid tokens. To be fair a valid token could also result in a DOS - but we generally expect large traffic volumes with valid tokens.

So why prevent invalid tokens from being cached?

The token auth can be likened to login operations. It is generally wise to slow this process down as much as possible. This way malicious requests take longer to process. This makes brute force attacks prohibitive. It also may (and I heavily stress the maybe) slow down DOS vectors - but it's very likely attackers run more than one process / thread and this slow down won't hinder them, only make the DOS worse by greatly increasing the request times. Still, security wisdom states login/auth processes should be as slow as your system can reasonably allow.

If we allowed the invalid tokens to be cached, a DOS with the same token would get processed a lot faster. This may allow more valid requests through, but this is unlikely to be a significant portion of the traffic. Caching the invalid tokens would have no affect on the time for a brute force attempt, as by design, a BF attack will change the token on every request.

However, a BF attack would destroy any viable valid cache. Since it's extremely likely the invalid tokens would consume all of the available cache space. This means valid cache hits will drop to roughly zero. Additionally, once the cache is maxed out, every request would result in a pruning/clean up. But since it's likely that all the invalid cached tokens will still have long expire times we resort to the alternative algorithm.

So by not caching the invalid tokens we greatly reduce our attack surface. Now we'd simply have to deal with the standard DOS attack responses which for us would mostly be handled by Heroku and dealt with at the router level - not the app level.

Finally, we've dropped the `current_user` check. This is mainly meant to be a shim for the test plugin to override who the currently authenticated user/token is. We will replace this logic with simply setting the internal ivar state/cache value appropriately.

/cc @RadiusNetworks/developers 