### PR TITLE
Handle subsequent cache reads which are frozen

### DIFF
--- a/lib/kracken/controllers/token_authenticatable.rb
+++ b/lib/kracken/controllers/token_authenticatable.rb
@@ -49,8 +49,8 @@ module Kracken
       end
 
       def shallow_freeze(val)
-        # nil is always frozen
-        return val if val.frozen?
+        # `nil` is frozen in Ruby 2.2 but not in Ruby 2.1
+        return val if val.frozen? || val.nil?
         val.transform_values!(&:freeze).freeze
       end
 

--- a/lib/kracken/controllers/token_authenticatable.rb
+++ b/lib/kracken/controllers/token_authenticatable.rb
@@ -51,7 +51,7 @@ module Kracken
       def shallow_freeze(val)
         # `nil` is frozen in Ruby 2.2 but not in Ruby 2.1
         return val if val.frozen? || val.nil?
-        val.transform_values!(&:freeze).freeze
+        val.each { |_k, v| v.freeze }.freeze
       end
 
       def current_auth_info

--- a/lib/kracken/controllers/token_authenticatable.rb
+++ b/lib/kracken/controllers/token_authenticatable.rb
@@ -45,7 +45,13 @@ module Kracken
         cache_key = "auth/token/#{token}"
         val = Rails.cache.read(cache_key)
         val ||= store_valid_auth(cache_key, &generate_cache)
-        val.transform_values!(&:freeze).freeze if val
+        shallow_freeze(val)
+      end
+
+      def shallow_freeze(val)
+        # nil is always frozen
+        return val if val.frozen?
+        val.transform_values!(&:freeze).freeze
       end
 
       def current_auth_info

--- a/spec/kracken/controllers/token_authenticatable_spec.rb
+++ b/spec/kracken/controllers/token_authenticatable_spec.rb
@@ -1,3 +1,4 @@
+require "rails_helper"
 require "support/base_controller_double"
 require "support/using_cache"
 
@@ -83,6 +84,25 @@ module Kracken
         end
 
         it "returns the auth info" do
+          expect(a_controller.authenticate_user_with_token!).to eq(
+            id: :any_id,
+            team_ids: [:some, :team, :ids],
+          ).and be_frozen
+        end
+
+        it "handles already frozen auth hashes" do
+          # This seems to happen on the 2nd cache read - despite the hash being
+          # frozen when put into the cache the first cache read will not be
+          # frozen. However, subsequent reads seem to be froze - this may be
+          # Rails version dependent. Regardless, we need to be aware of it.
+
+          # Initial cache request
+          expect(a_controller.authenticate_user_with_token!).to eq(
+            id: :any_id,
+            team_ids: [:some, :team, :ids],
+          ).and be_frozen
+
+          # Secondary cache request
           expect(a_controller.authenticate_user_with_token!).to eq(
             id: :any_id,
             team_ids: [:some, :team, :ids],


### PR DESCRIPTION
More quirks of the Rails cache. Initial testing showed that writing a frozen cache value returns an unfrozen value. Likely due to poor rigor in test methodology previous thought was that all reads of the cache would result in unfrozen values - even if that cache'd entry was refrozen.

This turns out to be false. The actual behavior is:

- Write frozen object to cache
- Read cache receiving an unfrozen version
- All subsequent cache reads will be unfrozen until one of the read versions is re-frozen
- Subsequent cache reads will be frozen

This was causing "500 Internal Server" errors in what appeared to be ActiveRecord calls. Digging into the stack trace showed it was our caching.

/cc @RadiusNetworks/developers 