### PR TITLE
Registration

### DIFF
--- a/lib/kracken.rb
+++ b/lib/kracken.rb
@@ -8,6 +8,7 @@ require "kracken/controllers/json_api_compatible"
 require "kracken/token_authenticator"
 require "kracken/credential_authenticator"
 require "kracken/authenticator"
+require "kracken/registration"
 
 module Kracken
   mattr_accessor :config

--- a/lib/kracken/registration.rb
+++ b/lib/kracken/registration.rb
@@ -1,0 +1,56 @@
+module Kracken
+  class Registration
+    attr_reader :response, :status
+
+    def post(params)
+      @response = connection.post do |req|
+        req.url '/auth/radius/registration.json'
+        req.headers['Content-Type'] = 'application/json'
+        req.body = post_body(params).to_json
+      end
+
+      @status = response.status
+
+      self
+    end
+
+    def body
+      if response
+        JSON.parse(response.body)
+      end
+    end
+
+    private
+
+    def post_body(params)
+      {
+        user: {
+          first_name: params["first_name"],
+          last_name: params["last_name"],
+          email: params["email"],
+          password: params["password"],
+          password_confirmation: params["password_confirmation"],
+          terms_of_service: params["terms_of_service"],
+          country: params["country"],
+        },
+        token: { description: params["token_description"] },
+        application: {
+          name: app_id,
+          secret:  app_secret,
+        },
+      }
+    end
+
+    def connection
+      @connection ||= Faraday.new(url: PROVIDER_URL)
+    end
+
+    def app_id
+      Kracken.config.app_id
+    end
+
+    def app_secret
+      Kracken.config.app_secret
+    end
+  end
+end

--- a/lib/kracken/version.rb
+++ b/lib/kracken/version.rb
@@ -1,3 +1,3 @@
 module Kracken
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/spec/kracken/registration_spec.rb
+++ b/spec/kracken/registration_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+module Kracken
+  RSpec.describe Registration do
+
+    let(:valid_registration) {
+      {
+        user: {
+          first_name: "Rory",
+          last_name: "Williams",
+          email: "rory@ponds.uk",
+          password: "I died and turned into a Roman.",
+          password_confirmation: "I died and turned into a Roman.",
+          terms_of_service: true,
+          country: 'United States',
+        },
+        application: { name: "client app_id", secret: "client app_secret" },
+        token: { description: "RSpec Test Token" }
+      }
+    }
+
+    def set_request(status, body=nil)
+      stub_request(:post, "https://account.radiusnetworks.com/auth/radius/registration.json")
+        .to_return(status: status, body: body)
+    end
+
+    it "parses the json and returns the token" do
+      reg = Registration.new
+      set_request 200, {
+        token: "I am a token",
+        email: "joe2@tester.com"
+      }.to_json
+
+      response = reg.post valid_registration
+      expect(response.body['token']).to eq "I am a token"
+    end
+
+    it "proxies any errors back to the caller" do
+      reg = Registration.new
+
+      set_request 500, {
+        message: ["What is that thing on your head?"]
+      }.to_json
+      response = reg.post valid_registration
+      expect(response.body['message']).to eq(["What is that thing on your head?"])
+    end
+
+  end
+end


### PR DESCRIPTION
This adds a Registration model that makes the external request to Kracken to create a new user. Any errors and status are simply proxied back to the caller.

Depends on https://github.com/RadiusNetworks/kracken/pull/143