### PR TITLE
don't store a reference to the User class

### DIFF
--- a/lib/kracken/config.rb
+++ b/lib/kracken/config.rb
@@ -3,12 +3,16 @@ module Kracken
     attr_accessor :app_id, :app_secret
     attr_writer :provider_url, :user_class
 
+    def initialize
+      @user_class = nil
+    end
+
     def provider_url
       @provider_url ||= PROVIDER_URL
     end
 
     def user_class
-      @user_class ||= ::User
+      @user_class || ::User
     end
   end
 end


### PR DESCRIPTION
The issue: `Kracken::Config` was storing a reference to the `User` class. In development, if Rails detects that an app's source has changed, it would reload the source (including the `User` class).  This would leave `Kracken` with a reference to an old version of the `User` class, which would cause a crash.

The (partial) fix: don't store a reference. When we need the class, get it via `::User` and don't store it in an instance variable. This wont solve the case where the app sets a custom `User` class, but none of our apps do this currently.