### PR TITLE
Improve gem integration

### DIFF
--- a/lib/kracken.rb
+++ b/lib/kracken.rb
@@ -9,6 +9,7 @@ require "kracken/token_authenticator"
 require "kracken/credential_authenticator"
 require "kracken/authenticator"
 require "kracken/registration"
+require "kracken/railtie" if defined?(Rails)
 
 module Kracken
   mattr_accessor :config

--- a/lib/kracken/controllers/json_api_compatible.rb
+++ b/lib/kracken/controllers/json_api_compatible.rb
@@ -2,7 +2,6 @@ module Kracken
   module Controllers
     module JsonApiCompatible
 
-
       module MungeAndMirror
         # Wraps the data root in an Array, if it is not already an Array. This
         # will not wrap the value if the resource root is not present.
@@ -75,15 +74,6 @@ module Kracken
         end
       end
 
-      def self.included(base)
-        base.instance_exec do
-          extend Macros
-
-          before_action :munge_chained_param_ids!
-          skip_before_action :verify_authenticity_token
-        end
-      end
-
       module DataIntegrity
         # Scan each item in the data root and enforce it has an id set.
         def enforce_resource_ids!
@@ -123,7 +113,17 @@ module Kracken
       end
       include VirtualAttributes
 
+      def self.included(base)
+        base.instance_exec do
+          extend Macros
+
+          before_action :munge_chained_param_ids!
+          skip_before_action :verify_authenticity_token
+        end
+      end
+
     # Common Actions Necessary in JSON API controllers
+    module_function
 
       # Wrap a block in an Active Record transaction
       #

--- a/lib/kracken/controllers/json_api_compatible.rb
+++ b/lib/kracken/controllers/json_api_compatible.rb
@@ -119,6 +119,18 @@ module Kracken
 
           before_action :munge_chained_param_ids!
           skip_before_action :verify_authenticity_token
+
+          if defined?(::ActiveRecord)
+            rescue_from ::ActiveRecord::RecordNotFound do |error|
+              # In order to use named captures we need to use an inline regex
+              # on the LHS.
+              #
+              # Source: http://rubular.com/r/NoQ4SZMav4
+              /Couldn't find( all)? (?<resource>\w+) with 'id'.?( \()?(?<ids>[,\s\w]+)\)?/ =~ error.message
+              resource = resource.underscore.pluralize
+              raise ResourceNotFound.new(resource, ids.strip)
+            end
+          end
         end
       end
 

--- a/lib/kracken/controllers/token_authenticatable.rb
+++ b/lib/kracken/controllers/token_authenticatable.rb
@@ -13,8 +13,10 @@ module Kracken
         end
       end
 
-      # NOTE: Monkey-patch until this is merged into the gem
+      # Customize the `authenticate_or_request_with_http_token` process:
+      # http://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token/ControllerMethods.html#method-i-request_http_token_authentication
       def request_http_token_authentication(realm = 'Application')
+        # Modified from https://github.com/rails/rails/blob/60d0aec7/actionpack/lib/action_controller/metal/http_authentication.rb#L490-L499
         headers["WWW-Authenticate"] = %(Token realm="#{realm.gsub(/"/, "")}")
         raise TokenUnauthorized, "Invalid Credentials"
       end

--- a/lib/kracken/error.rb
+++ b/lib/kracken/error.rb
@@ -17,7 +17,7 @@ module Kracken
       @missing_ids = Array(missing_ids)
       @resource    = resource
       super(
-        "Couldn't find #{resource} with id(s): #{missing_ids.join(', ')}"
+        "Couldn't find #{@resource} with id(s): #{@missing_ids.join(', ')}"
       )
     end
   end

--- a/lib/kracken/json_api/public_exceptions.rb
+++ b/lib/kracken/json_api/public_exceptions.rb
@@ -7,9 +7,16 @@ module Kracken
       end
 
       def call(env)
-        app.call(env)
+        if JsonApi.has_path?(JsonApi::Request.new(env))
+          capture_error(env)
+        else
+          @app.call(env)
+        end
+      end
+
+      def capture_error(env)
+        @app.call(env)
       rescue Exception => exception
-        raise exception unless JsonApi.has_path?(JsonApi::Request.new(env))
         render_json_error(ExceptionWrapper.new(env, exception))
       end
 

--- a/lib/kracken/json_api/public_exceptions.rb
+++ b/lib/kracken/json_api/public_exceptions.rb
@@ -27,8 +27,8 @@ module Kracken
 
       def show_error_details?(wrapper)
         wrapper.is_details_exception? ||
-          ( Rails.application.config.consider_all_requests_local &&
-            wrapper.status_code == 500)
+          Rails.application.config.consider_all_requests_local ||
+          (Rails.env.test? && wrapper.status_code == 500)
       end
 
       def error_as_json(wrapper)

--- a/lib/kracken/railtie.rb
+++ b/lib/kracken/railtie.rb
@@ -1,0 +1,11 @@
+require "kracken/json_api"
+
+module Kracken
+  # Railtie to hook into Rails.
+  class Railtie < ::Rails::Railtie
+    initializer "kracken.json_api.public_exceptions" do |app|
+      app.middleware.insert_after ActionDispatch::DebugExceptions,
+                                  ::Kracken::JsonApi::PublicExceptions
+    end
+  end
+end


### PR DESCRIPTION
This fixes a few :bug:s and improves the gem's integration with Rails apps.

**Enhancements:**

- Capture `ActiveRecord::RecordNotFound` errors in controllers using `rescue_from` wrapping them in a `ResourceNotFound` error
- Include a `Railtie` injecting the custom error handling middleware for endpoints declared with `json_api`
- Allow environments which consider all requests local to see the stack trace details in JSON api error messages
- Log captured JSON api errors

**Bug Fixes:**

- Fix `ResourceNotFound` error message format when a non-array `missing_ids` are provided
- Turn custom middleware into a noop for non-JSON api resources so that errors raised do not appear to originate from this gem
- Handle routing errors so that they properly formatted in our standard JSON api error format
