### PR TITLE
Relax Rails version requirement to allow for 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ cache: bundler
 sudo: false
 script: bin/rake
 rvm:
-  - 2.3
+  - 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ cache: bundler
 sudo: false
 script: bin/rake
 rvm:
-  - 2.1
-  - 2.2
+  - 2.3

--- a/app/controllers/kracken/application_controller.rb
+++ b/app/controllers/kracken/application_controller.rb
@@ -1,4 +1,0 @@
-module Kracken
-  class ApplicationController < ActionController::Base
-  end
-end

--- a/app/controllers/kracken/sessions_controller.rb
+++ b/app/controllers/kracken/sessions_controller.rb
@@ -1,10 +1,5 @@
 module Kracken
-  class SessionsController < ApplicationController
-    skip_before_filter :authenticate_user!, except: [:index]
-    skip_before_filter :handle_user_cache_cookie!, except: [:index]
-
-    def index
-    end
+  class SessionsController < ActionController::Base
 
     def create
       @user = user_class.find_or_create_from_auth_hash(auth_hash)

--- a/kracken.gemspec
+++ b/kracken.gemspec
@@ -15,12 +15,12 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'rails', '~> 4.0'
+  s.add_dependency 'rails', '~> 5.0'
   s.add_dependency 'omniauth', '~> 1.0'
   s.add_dependency 'faraday', '~> 0.8'
   s.add_dependency 'omniauth-oauth2', '~> 1.1'
 
-  s.add_development_dependency 'rspec-rails', '~> 3.4'
+  s.add_development_dependency 'rspec-rails', '~> 3.5'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'
   s.add_development_dependency 'webmock'

--- a/kracken.gemspec
+++ b/kracken.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'rails', '~> 5.0'
+  s.add_dependency 'rails', [">= 4.0", "< 6.0"]
   s.add_dependency 'omniauth', '~> 1.0'
   s.add_dependency 'faraday', '~> 0.8'
   s.add_dependency 'omniauth-oauth2', '~> 1.1'

--- a/lib/kracken/controllers/json_api_compatible.rb
+++ b/lib/kracken/controllers/json_api_compatible.rb
@@ -80,7 +80,6 @@ module Kracken
           extend Macros
 
           before_action :munge_chained_param_ids!
-          skip_before_action :verify_authenticity_token
         end
       end
 

--- a/lib/kracken/controllers/json_api_compatible.rb
+++ b/lib/kracken/controllers/json_api_compatible.rb
@@ -126,7 +126,7 @@ module Kracken
           extend Macros
 
           before_action :munge_chained_param_ids!
-          skip_before_action :verify_authenticity_token
+          skip_before_action :verify_authenticity_token, raise: false
 
           if defined?(::ActiveRecord)
             rescue_from ::ActiveRecord::RecordNotFound do |error|

--- a/lib/kracken/controllers/token_authenticatable.rb
+++ b/lib/kracken/controllers/token_authenticatable.rb
@@ -14,7 +14,7 @@ module Kracken
       end
 
       # NOTE: Monkey-patch until this is merged into the gem
-      def request_http_token_authentication(realm = 'Application')
+      def request_http_token_authentication(realm = 'Application', message = nil)
         headers["WWW-Authenticate"] = %(Token realm="#{realm.gsub(/"/, "")}")
         raise TokenUnauthorized, "Invalid Credentials"
       end

--- a/lib/kracken/controllers/token_authenticatable.rb
+++ b/lib/kracken/controllers/token_authenticatable.rb
@@ -13,10 +13,16 @@ module Kracken
         end
       end
 
-      # NOTE: Monkey-patch until this is merged into the gem
-      def request_http_token_authentication(realm = 'Application', message = nil)
-        headers["WWW-Authenticate"] = %(Token realm="#{realm.gsub(/"/, "")}")
-        raise TokenUnauthorized, "Invalid Credentials"
+      if Rails::VERSION::MAJOR >= 5
+        def request_http_token_authentication(realm = 'Application', message = nil)
+          headers["WWW-Authenticate"] = %(Token realm="#{realm.gsub(/"/, "")}")
+          raise TokenUnauthorized, "Invalid Credentials"
+        end
+      else
+        def request_http_token_authentication(realm = 'Application')
+          headers["WWW-Authenticate"] = %(Token realm="#{realm.gsub(/"/, "")}")
+          raise TokenUnauthorized, "Invalid Credentials"
+        end
       end
 
     private

--- a/spec/dummy/app/controllers/welcome_controller.rb
+++ b/spec/dummy/app/controllers/welcome_controller.rb
@@ -1,5 +1,5 @@
 class WelcomeController < ApplicationController
-  skip_before_filter :authenticate_user!, only: [:index]
+  skip_before_action :authenticate_user!, only: [:index]
 
   def index
   end

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -20,7 +20,7 @@ Dummy::Application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_files = false
+  config.public_file_server.enabled = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -15,7 +15,7 @@ Dummy::Application.configure do
 
   # Configure static asset server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
-  config.static_cache_control = "public, max-age=3600"
+  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -14,7 +14,7 @@ Dummy::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_files = true
+  config.public_file_server.enabled = true
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -14,8 +14,15 @@ Dummy::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.public_file_server.enabled = true
-  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+  if config.respond_to? :public_file_server
+    # Hot new Rails 5 Settings
+    config.public_file_server.enabled = true
+    config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+  else
+    # Deprecated Rails 4 Settings
+    config.serve_static_files = true
+    config.static_cache_control = "public, max-age=3600"
+  end
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -18,7 +18,7 @@ module Kracken
         stub_request(:get, "https://account.radiusnetworks.com/auth/radius/user.json?oauth_token=123")
           .to_return(status: 200, body: json)
 
-        get api_index_path, nil, headers_with_token("123")
+        get api_index_path, params: {}, headers: headers_with_token("123")
 
         expect(response.status).to be 200
       end

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -18,7 +18,12 @@ module Kracken
         stub_request(:get, "https://account.radiusnetworks.com/auth/radius/user.json?oauth_token=123")
           .to_return(status: 200, body: json)
 
-        get api_index_path, params: {}, headers: headers_with_token("123")
+        # Temporary work around while we support versions of Rails before 4
+        if Rails::VERSION::MAJOR >= 5
+          get api_index_path, params: {}, headers: headers_with_token("123")
+        else
+          get api_index_path, {}, headers_with_token("123")
+        end
 
         expect(response.status).to be 200
       end


### PR DESCRIPTION
Needed for the new Display Kit repo.

Turns out that rails 5 had different autoloading behavior, and was autoloading `Kracken::ApplicationController` when it referenced `ApplicationController` in the `Kracken` module. I am not sure who had the better behavior, rails 4 or rails 5, but this could be resolved by dropping the dependency on the `ApplicationController` and just inheriting from `ActionController::Base` directly.

Once I did that just needed to remove the `skip_before_filters` and things seemed to work.
