### PR TITLE
Expose linked accounts in main auth hash

### DIFF
--- a/lib/omniauth/strategies/radius.rb
+++ b/lib/omniauth/strategies/radius.rb
@@ -31,6 +31,7 @@ module OmniAuth
             uid
             confirmed
             teams
+            linked_accounts
             admin
             subscription_level
           }


### PR DESCRIPTION
This includes the linked provider account data in the `info` auth hash. While this isn't technically part of the OAuth spec it follows our convention of including linked data in the main hash (we did this previously for `teams`).

Also, as with the `teams` data we do not perform any further attribute filtering. It is up to the consumers to allow or ignore attributes according to their internal implementation details.

This is necessary for our web services to consume the results of RadiusNetworks/kracken#187