### PR TITLE
Use `::User` for the `user_class` in the auth module

### DIFF
--- a/lib/kracken/config.rb
+++ b/lib/kracken/config.rb
@@ -1,7 +1,7 @@
 module Kracken
   class Config
-    attr_accessor :app_id, :app_secret
-    attr_writer :provider_url, :user_class
+    attr_accessor :app_id, :app_secret, :user_class
+    attr_writer :provider_url
 
     def initialize
       @user_class = nil
@@ -12,7 +12,7 @@ module Kracken
     end
 
     def user_class
-      @user_class || ::User
+      ::User
     end
   end
 end

--- a/spec/kracken/controllers/token_authenticatable_spec.rb
+++ b/spec/kracken/controllers/token_authenticatable_spec.rb
@@ -125,22 +125,13 @@ module Kracken
         end
 
         it "lazy loads the current user" do
-          begin
-            # Ensure we cannot lookup a user - doing so would raise an error
-            org_user_class = Kracken.config.user_class
-            user_class = double("AnyUserClass")
-            Kracken.config.user_class = user_class
+          # Action under test
+          a_controller.authenticate_user_with_token!
 
-            # Action under test
-            a_controller.authenticate_user_with_token!
+          # Make sure we perform the lookup as expected now
+          expect(::User).to receive(:find).with(:any_id).and_return(:user)
 
-            # Make sure we perform the lookup as expected now
-            expect(user_class).to receive(:find).with(:any_id).and_return(:user)
-
-            expect(a_controller.current_user).to be :user
-          ensure
-            Kracken.config.user_class = org_user_class
-          end
+          expect(a_controller.current_user).to be :user
         end
       end
 


### PR DESCRIPTION
This removes the ability to set custom user class in kracken's config.
So you will no longer be able to do this:

```
Kracken.config.user_class = Account
```

Instead it just assumes a AR model called `::User`.

This was required because auto-reloading was broken in Rails 5. Changing
the user model or logging in would cause the following exception to be
raised:

```
A copy of User has been removed from the module tree but is still active!
```

Or even more helpful:

```
Cannot assign property of type User to object of type User
```

The module would store a reference the `User` class and that wouldn't be
reinitalized between requests. To work around this, we just use the
constant.

Luckily all our Rails apps follow that convention.

cc @AT89 