### PR TITLE
Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,16 @@ matrix:
   include:
     - rvm: 2.2.3
       env: RAILS_VERSION="4.2.5"
+    # Rails doesn't officially support Ruby 2.4 yet (so also test latest stable)
+    - rvm: 2.4.0
+      env: RAILS_VERSION='4-2-stable'
+  allow_failures:
+    # Rails doesn't officially support Ruby 2.4 yet (so also test latest stable)
+    - rvm: 2.4.0
+      env: RAILS_VERSION='~> 4.2.0'
+    - rvm: 2.4.0
+      env: RAILS_VERSION='4-2-stable'
+    # Rails doesn't officially support Ruby 2.4 yet (multiple fixes in pipeline)
+    - rvm: 2.4.0
+      env: RAILS_VERSION='~> 4.2.0'
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,13 @@ cache: bundler
 sudo: false
 script: bin/rake
 rvm:
-  - 2.3.1
+  - 2.3.3
+  - 2.4.0
+env:
+  - RAILS_VERSION='~> 5.0.0'
+  - RAILS_VERSION='~> 4.2.0'
+matrix:
+  include:
+    - rvm: 2.2.3
+      env: RAILS_VERSION="4.2.5"
+  fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,6 @@ gemspec
 
 # To use debugger
 # gem 'debugger'
+
+rails_dependencies_gemfile = File.expand_path("../Gemfile-rails-dependencies", __FILE__)
+eval_gemfile rails_dependencies_gemfile

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -4,7 +4,23 @@ version = ENV.fetch('RAILS_VERSION') {
 }
 
 if version && !version.empty?
-  gem "rails", version
+  if version.end_with?("stable")
+    gem_list = %w[
+      rails
+      railties
+      actionmailer
+      actionpack
+      activerecord
+      activesupport
+      activejob
+      actionview
+    ]
+    gem_list.each do |rails_gem|
+      gem rails_gem, git: "https://github.com/rails/rails.git", branch: version
+    end
+  else
+    gem "rails", version
+  end
 elsif RUBY_VERSION.to_f < 2.4
   gem "rails", "~> 4.2.0"
 else

--- a/Gemfile-rails-dependencies
+++ b/Gemfile-rails-dependencies
@@ -1,0 +1,12 @@
+version_file = File.expand_path("../.rails-version", __FILE__)
+version = ENV.fetch('RAILS_VERSION') {
+  File.read(version_file).chomp if File.exist?(version_file)
+}
+
+if version && !version.empty?
+  gem "rails", version
+elsif RUBY_VERSION.to_f < 2.4
+  gem "rails", "~> 4.2.0"
+else
+  gem "rails", "~> 5.0"
+end

--- a/lib/kracken/json_api/public_exceptions.rb
+++ b/lib/kracken/json_api/public_exceptions.rb
@@ -109,7 +109,7 @@ module Kracken
         case status
         when Symbol
           code = Rack::Utils::SYMBOL_TO_STATUS_CODE[status]
-        when Fixnum
+        when Integer
           code = status
         when String
           code = status.to_i


### PR DESCRIPTION
This fixes a Ruby 2.4 deprecation warning:

    warning: constant ::Fixnum is deprecated

It also expands the build matrix so that we ensure cross version compatibility.