### PR TITLE
Add support for `system` specs

### DIFF
--- a/lib/kracken/rspec.rb
+++ b/lib/kracken/rspec.rb
@@ -80,18 +80,7 @@ if defined? RSpec
 
     c.before do
       Kracken::Controllers::TokenAuthenticatable.clear_auth_cache
-    end
-
-    c.before(type: :kracken) do
-        Kracken::SpecHelper.current_user = nil
-    end
-
-    c.before(type: :controller) do
-        Kracken::SpecHelper.current_user = nil
-    end
-
-    c.before(type: :request) do
-        Kracken::SpecHelper.current_user = nil
+      Kracken::SpecHelper.current_user = nil
     end
   end
 end

--- a/lib/kracken/rspec.rb
+++ b/lib/kracken/rspec.rb
@@ -74,6 +74,7 @@ if defined? RSpec
   RSpec.configure do |c|
     c.include Kracken::SpecHelper::Controller, type: :controller
     c.include Kracken::SpecHelper::Request, type: :feature
+    c.include Kracken::SpecHelper::Request, type: :system
     c.include Kracken::SpecHelper::Request, type: :kracken
     c.include Kracken::SpecHelper::Request, type: :request
 


### PR DESCRIPTION
This hooks into the new Rails `system` spec type. It also fixes a state leak :bug: which doesn't clear the current user for `feature` and `system` specs; this :bug: would also affect any other spec which manually includes the kracken helpers as well.