### PR TITLE
Add task to clean up old OAuth credentials

### DIFF
--- a/lib/tasks/kracken.rake
+++ b/lib/tasks/kracken.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+namespace :kracken do
+  namespace :sweep do
+    desc "Remove expired credentials after threshold days " \
+         "(default threshold is 90 days)"
+    task :credentials, %i[threshold] => :environment do |_t, args|
+      threshold = args.fetch(:threshold) { 90 }.to_i.days
+      timestamp = threshold.ago
+      Rails.logger.info "Clearing expired `Credentials` older than " \
+                        "#{threshold.inspect} (#{timestamp})"
+      expired = Credentials.where(expires: true)
+                           .where("expires_at < ?", timestamp)
+                           .destroy_all
+                           .size
+      Rails.logger.info "Removed: #{expired} credentials"
+      threshold *= 2
+      timestamp = threshold.ago
+      Rails.logger.info "Clearing legacy `Credentials` older than " \
+                        "#{threshold.inspect} (#{timestamp})"
+      legacy = Credentials.where(expires: [nil, false])
+                          .where("updated_at < ?", timestamp)
+                          .destroy_all
+                          .size
+      Rails.logger.info "Removed: #{legacy} credentials"
+    end
+  end
+end

--- a/lib/tasks/kracken_tasks.rake
+++ b/lib/tasks/kracken_tasks.rake
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-# desc "Explaining what the task does"
-# task :kracken do
-#   # Task goes here
-# end


### PR DESCRIPTION
This is a helper task to clean up old OAuth tokens. There are potentially two types of tokens:

  - expired tokens
  - legacy tokens (those without an expiration; these are not personal tokens)

We are phasing out the legacy tokens for security reasons. In the future all OAuth tokens will have fixed expiration windows. This simply means we'll expect OAuth apps to have the user re-authenticate every so often. Looking at other companies policies:

  - [Facebook uses 90 days](https://developers.facebook.com/docs/facebook-login/access-tokens/refreshing)
  - [Google uses 6 months](https://developers.google.com/identity/protocols/OAuth2#expiration)

At this time we feel 90 days is a good default. The task is configurable depending on the app's requirements.