### PR TITLE
Minor fixes deprecations

### DIFF
--- a/app/controllers/kracken/sessions_controller.rb
+++ b/app/controllers/kracken/sessions_controller.rb
@@ -13,7 +13,6 @@ module Kracken
 
     def destroy
       reset_session
-      flash[:notice] = "Signed out successfully."
       redirect_to "#{provider_url}/users/sign_out#{signout_redirect_query}"
     end
 

--- a/lib/kracken/controllers/token_authenticatable.rb
+++ b/lib/kracken/controllers/token_authenticatable.rb
@@ -148,6 +148,15 @@ module Kracken
       # transfer the knowledge about also checking for the params.
       def munge_header_auth_token!
         return unless params[:token]
+        deprecation = ActiveSupport::Deprecation.new("1.0", "kracken")
+        deprecation.behavior = ActiveSupport::Deprecation.behavior
+        deprecation.silenced = ActiveSupport::Deprecation.silenced
+        controller_action = "#{request.controller_class}#" \
+          "#{request.path_parameters[:action] || :index}"
+        deprecation.warn "[#{controller_action}][kracken] Passing auth " \
+          "tokens as query parameters is deprecated. This is insecure and " \
+          "will be removed in a future version of Kracken. Use the " \
+          "'Authorization' header instead."
         request.env['HTTP_AUTHORIZATION'] = "Token token=\"#{params[:token]}\""
       end
 

--- a/lib/kracken/json_api/public_exceptions.rb
+++ b/lib/kracken/json_api/public_exceptions.rb
@@ -15,7 +15,8 @@ module Kracken
         trace = wrapper.framework_trace if trace.empty?
 
         ActiveSupport::Deprecation.silence do
-          message = "\n#{exception.class} (#{exception.message}):\n"
+          # After Ruby 2.2.3 support change `String.new` to `+` literal
+          message = String.new("\n#{exception.class} (#{exception.message}):\n")
           message << exception.annoted_source_code.to_s if exception.respond_to?(:annoted_source_code)
           message << "  " << trace.join("\n  ")
           logger.fatal("#{message}\n\n")

--- a/lib/kracken/rspec.rb
+++ b/lib/kracken/rspec.rb
@@ -82,6 +82,7 @@ if defined? RSpec
 
     c.before do
       Kracken::Controllers::TokenAuthenticatable.clear_auth_cache
+      Kracken::Authenticator.cache.clear
       Kracken::SpecHelper.current_user = nil
     end
   end

--- a/spec/kracken/controllers/token_authenticatable_spec.rb
+++ b/spec/kracken/controllers/token_authenticatable_spec.rb
@@ -36,7 +36,9 @@ module Kracken
           a_controller.params = { token: expected_token }
 
           expect {
-            a_controller.authenticate_user_with_token!
+            ActiveSupport::Deprecation.silence do
+              a_controller.authenticate_user_with_token!
+            end
           }.to change {
             a_controller.request.env
           }.from(

--- a/spec/support/base_controller_double.rb
+++ b/spec/support/base_controller_double.rb
@@ -2,15 +2,15 @@
 
 module Kracken
   class BaseControllerDouble
-    Request = Struct.new(:env)
+    Request = Struct.new(:env, :controller_class, :path_parameters)
 
     attr_accessor :session, :cookies, :request, :params
 
     def initialize
       @session = {}
       @cookies = {}
-      @request = Request.new({})
-      @params = {}
+      @params = { action: :index }
+      @request = Request.new({}, self.class, @params.slice(:action))
     end
 
     def self.helper_method(*) ; end


### PR DESCRIPTION
A few minor fixes detected during integration. This also adds a deprecation warning for any system still attempting to support query auth tokens via query parameters.