### PR TITLE
Fix rake task for Rails 4.2

### DIFF
--- a/lib/tasks/kracken.rake
+++ b/lib/tasks/kracken.rake
@@ -5,19 +5,19 @@ namespace :kracken do
     desc "Remove expired credentials after threshold days " \
          "(default threshold is 90 days)"
     task :credentials, %i[threshold] => :environment do |_t, args|
-      threshold = args.fetch(:threshold) { 90 }.to_i.days
-      timestamp = threshold.ago
+      threshold = args.fetch(:threshold) { 90 }.to_i
+      timestamp = threshold.days.ago
       Rails.logger.info "Clearing expired `Credentials` older than " \
-                        "#{threshold.inspect} (#{timestamp})"
+                        "#{threshold.days.inspect} (#{timestamp})"
       expired = Credentials.where(expires: true)
                            .where("expires_at < ?", timestamp)
                            .destroy_all
                            .size
       Rails.logger.info "Removed: #{expired} credentials"
       threshold *= 2
-      timestamp = threshold.ago
+      timestamp = threshold.days.ago
       Rails.logger.info "Clearing legacy `Credentials` older than " \
-                        "#{threshold.inspect} (#{timestamp})"
+                        "#{threshold.days.inspect} (#{timestamp})"
       legacy = Credentials.where(expires: [nil, false])
                           .where("updated_at < ?", timestamp)
                           .destroy_all


### PR DESCRIPTION
Rails 4.2 does not preserve the duration type on multiplication:

  ```ruby
  x = 5.days
  # => 5 days

  x *= 2
  # => 864000
  ```

This fixes the Rake task so that we use the correct when calculating the timestamp. In order to get the nicely worded output for the duration in the logs we need to re-cast the duration at that point.