### PR TITLE
Temporarily drop deprecation notice

### DIFF
--- a/lib/kracken/controllers/token_authenticatable.rb
+++ b/lib/kracken/controllers/token_authenticatable.rb
@@ -148,15 +148,6 @@ module Kracken
       # transfer the knowledge about also checking for the params.
       def munge_header_auth_token!
         return unless params[:token]
-        deprecation = ActiveSupport::Deprecation.new("1.0", "kracken")
-        deprecation.behavior = ActiveSupport::Deprecation.behavior
-        deprecation.silenced = ActiveSupport::Deprecation.silenced
-        controller_action = "#{request.controller_class}#" \
-          "#{request.path_parameters[:action] || :index}"
-        deprecation.warn "[#{controller_action}][kracken] Passing auth " \
-          "tokens as query parameters is deprecated. This is insecure and " \
-          "will be removed in a future version of Kracken. Use the " \
-          "'Authorization' header instead."
         request.env['HTTP_AUTHORIZATION'] = "Token token=\"#{params[:token]}\""
       end
 


### PR DESCRIPTION
This is breaking apps on 4.2. Looks like they don't have the same methods on `request`. Sadly we don't have the time to implement a fix to keep the warning so we're just dropping it. We plan on adding it back in later once we have more time.