### PR TITLE
Add `sign_out` helper for request specs

### DIFF
--- a/lib/kracken/rspec.rb
+++ b/lib/kracken/rspec.rb
@@ -17,6 +17,10 @@ module Kracken
         Kracken::SpecHelper.current_user = user
       end
 
+      def sign_out(_ignored = nil)
+        Kracken::SpecHelper.current_user = nil
+      end
+
       def token_authorize(user, token:)
         Kracken::Controllers::TokenAuthenticatable::cache_valid_auth(token, force: true) do
           { id: user.id, team_ids: user.team_ids }
@@ -29,7 +33,7 @@ module Kracken
         Kracken::SpecHelper.current_user = user
       end
 
-      def sign_out(ignored = nil)
+      def sign_out(_ignored = nil)
         Kracken::SpecHelper.current_user = nil
       end
 

--- a/lib/kracken/rspec.rb
+++ b/lib/kracken/rspec.rb
@@ -12,7 +12,7 @@ module Kracken
       @@current_user = current_user
     end
 
-    module Request
+    module SignInShim
       def sign_in(user = nil)
         Kracken::SpecHelper.current_user = user
       end
@@ -20,6 +20,10 @@ module Kracken
       def sign_out(_ignored = nil)
         Kracken::SpecHelper.current_user = nil
       end
+    end
+
+    module Request
+      include SignInShim
 
       def token_authorize(user, token:)
         Kracken::Controllers::TokenAuthenticatable::cache_valid_auth(token, force: true) do
@@ -29,21 +33,13 @@ module Kracken
     end
 
     module Controller
-      def sign_in(user = nil)
-        Kracken::SpecHelper.current_user = user
-      end
-
-      def sign_out(_ignored = nil)
-        Kracken::SpecHelper.current_user = nil
-      end
+      include SignInShim
 
       def current_user
         Kracken::SpecHelper.current_user
       end
     end
-
   end
-
 end
 
 # monkey patch current_user


### PR DESCRIPTION
It's not often this is necessary, but when there is shared state that needs to be undone it may be necessary. Prior to this the same thing can be accomplished using `sign_in nil` but that's a bit clunky. This adds the more intentional revealing `sign_out` helper, which also provides better interface parity between the spec types.