### PR TITLE
Allow `ActionController::Params` as the data root

### DIFF
--- a/lib/kracken/controllers/json_api_compatible.rb
+++ b/lib/kracken/controllers/json_api_compatible.rb
@@ -177,7 +177,7 @@ module Kracken
       # If the data was a Hash, then the single `permit_params` object is returned.
       # Or the tuple [`id`, `permitd_params`] respectively.
       def process_params(permitted_params)
-        single_resource = Hash === data_root
+        single_resource = data_root.respond_to?(:to_hash)
         data = Array.wrap(data_root)
         mapping = if params[:id].blank?
                     data.map { |attrs| attrs.permit(permitted_params) }


### PR DESCRIPTION
With Rails 5 `ActionController::Params` no longer inherits from `Hash`. This fixes the JSON API endpoint compatibility to support any "hash" data root.