### PR TITLE
Add Ruby 2.7 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6' ]
+        ruby: [ '2.5', '2.6', '2.7' ]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Also drop Ruby 2.4 since this is the Rails 6 branch and according to their docs:

> Rails 6 requires Ruby 2.5.0 or newer.