### PR TITLE
Modifies cookie cache value check to also check with redis-based value

### DIFF
--- a/app/controllers/kracken/sessions_controller.rb
+++ b/app/controllers/kracken/sessions_controller.rb
@@ -7,7 +7,7 @@ module Kracken
     def create
       @user = user_class.find_or_create_from_auth_hash(auth_hash)
       session[:user_id] = @user.id
-      session[:user_cache_key] = cookies[:_radius_user_cache_key]
+      session[:user_cache_key] = SESSION_REDIS.get(user_session_key(@user.id))
       session[:token_expires_at] = Time.zone.at(auth_hash[:credentials][:expires_at])
       redirect_to return_to_path
     end
@@ -43,6 +43,10 @@ module Kracken
       current_root = URI(request.url)
       current_root.path = ''
       "?redirect_to=#{CGI.escape(current_root.to_s)}"
+    end
+
+    def user_session_key(id)
+      "rnsession:#{id}"
     end
   end
 end

--- a/app/controllers/kracken/sessions_controller.rb
+++ b/app/controllers/kracken/sessions_controller.rb
@@ -8,7 +8,7 @@ module Kracken
       @user = user_class.find_or_create_from_auth_hash(auth_hash)
       session[:user_id] = @user.id
       session[:user_uid] = @user.uid
-      session[:user_cache_key] = ::SessionManager.get(@user.uid)
+      session[:user_cache_key] = Kracken::SessionManager.get(@user.uid)
       session[:token_expires_at] = Time.zone.at(auth_hash[:credentials][:expires_at])
 
       redirect_to return_to_path
@@ -45,10 +45,6 @@ module Kracken
       current_root = URI(request.url)
       current_root.path = ''
       "?redirect_to=#{CGI.escape(current_root.to_s)}"
-    end
-
-    def user_session_key(id)
-      "rnsession:#{id}"
     end
   end
 end

--- a/app/controllers/kracken/sessions_controller.rb
+++ b/app/controllers/kracken/sessions_controller.rb
@@ -8,7 +8,7 @@ module Kracken
       @user = user_class.find_or_create_from_auth_hash(auth_hash)
       session[:user_id] = @user.id
       session[:user_uid] = @user.uid
-      session[:user_cache_key] = SESSION_REDIS.get(user_session_key(@user.uid))
+      session[:user_cache_key] = SessionManager.get(@user.uid)
       session[:token_expires_at] = Time.zone.at(auth_hash[:credentials][:expires_at])
 
       redirect_to return_to_path

--- a/app/controllers/kracken/sessions_controller.rb
+++ b/app/controllers/kracken/sessions_controller.rb
@@ -8,7 +8,7 @@ module Kracken
       @user = user_class.find_or_create_from_auth_hash(auth_hash)
       session[:user_id] = @user.id
       session[:user_uid] = @user.uid
-      session[:user_cache_key] = SessionManager.get(@user.uid)
+      session[:user_cache_key] = ::SessionManager.get(@user.uid)
       session[:token_expires_at] = Time.zone.at(auth_hash[:credentials][:expires_at])
 
       redirect_to return_to_path

--- a/app/controllers/kracken/sessions_controller.rb
+++ b/app/controllers/kracken/sessions_controller.rb
@@ -7,8 +7,10 @@ module Kracken
     def create
       @user = user_class.find_or_create_from_auth_hash(auth_hash)
       session[:user_id] = @user.id
-      session[:user_cache_key] = SESSION_REDIS.get(user_session_key(@user.id))
+      session[:user_uid] = @user.uid
+      session[:user_cache_key] = SESSION_REDIS.get(user_session_key(@user.uid))
       session[:token_expires_at] = Time.zone.at(auth_hash[:credentials][:expires_at])
+
       redirect_to return_to_path
     end
 

--- a/lib/kracken.rb
+++ b/lib/kracken.rb
@@ -12,6 +12,7 @@ require "kracken/credential_authenticator"
 require "kracken/authenticator"
 require "kracken/registration"
 require "kracken/railtie" if defined?(Rails)
+require "kracken/session_manager"
 
 module Kracken
   mattr_accessor :config

--- a/lib/kracken/controllers/authenticatable.rb
+++ b/lib/kracken/controllers/authenticatable.rb
@@ -71,7 +71,7 @@ module Kracken
       #    delete the cookie
       #
       def handle_user_cache_cookie!
-        return redirect_to_sign_in unless session_present?
+        return unless session_present?
         return if session_and_redis_match?
 
         delete_session_data
@@ -113,27 +113,20 @@ module Kracken
       private
 
       def session_present?
-        session[:user_id] && session[:user_cache_key]
+        session[:user_uid] && session[:user_cache_key]
       end
 
       def session_and_redis_match?
-        ::SessionManager.get(session[:user_uid]) == session[:user_cache_key]
+        Kracken::SessionManager.get(session[:user_uid]) == session[:user_cache_key]
       end
 
       def delete_session_data
         # Sign out current user
         session.delete :user_id
 
-        # Clear that user's cache key
+        # Clear that user's cache data
+        session.delete :user_uid
         session.delete :user_cache_key
-      end
-
-      def clear_cache_cookie_and_sign_out
-        # Delete the cookie to prevent redirect loops
-        cookies.delete :_radius_user_cache_key
-
-        # Redirect to the account app
-        redirect_to_sign_in
       end
 
       def user_class

--- a/lib/kracken/controllers/authenticatable.rb
+++ b/lib/kracken/controllers/authenticatable.rb
@@ -6,7 +6,7 @@ module Kracken
 
       def self.included(base)
         base.instance_exec do
-          before_action :handle_user_cache_cookie!
+          before_action :handle_user_cache_key!
           before_action :authenticate_user!
           helper_method :sign_out_path, :sign_up_path, :sign_in_path,
                         :current_user, :user_signed_in?
@@ -64,13 +64,12 @@ module Kracken
       #
       # This method will:
       #
-      #  - Check for the `_radius_user_cache_key` tld cookie
-      #  - If the key is "none" log them out
+      #  - Check for the presence of a user cache key in Redis
       #  - Compare it to the `user_cache_key` in the session
       #  - If they don't match, redirect them to the oauth provider and
-      #    delete the cookie
+      #    delete the session
       #
-      def handle_user_cache_cookie!
+      def handle_user_cache_key!
         return unless session_present?
         return if session_and_redis_match?
 

--- a/lib/kracken/controllers/authenticatable.rb
+++ b/lib/kracken/controllers/authenticatable.rb
@@ -129,7 +129,7 @@ module Kracken
       end
 
       def session_and_redis_match?
-        SESSION_REDIS.get(user_session_key(session[:user_id])) == session[:user_cache_key]
+        SESSION_REDIS.get(user_session_key(session[:user_uid])) == session[:user_cache_key]
       end
 
       def user_session_key(id)

--- a/lib/kracken/controllers/authenticatable.rb
+++ b/lib/kracken/controllers/authenticatable.rb
@@ -117,7 +117,7 @@ module Kracken
       end
 
       def session_and_redis_match?
-        SessionManager.update(session[:user_uid]) == session[:user_cache_key]
+        ::SessionManager.get(session[:user_uid]) == session[:user_cache_key]
       end
 
       def delete_session_data

--- a/lib/kracken/controllers/authenticatable.rb
+++ b/lib/kracken/controllers/authenticatable.rb
@@ -49,7 +49,7 @@ module Kracken
 
       def check_token_expiry!
         if session[:token_expires_at].nil? || session[:token_expires_at] < Time.zone.now
-          session.delete :user_id
+          delete_session_data
         end
       end
 

--- a/lib/kracken/session_manager.rb
+++ b/lib/kracken/session_manager.rb
@@ -13,7 +13,7 @@ class SessionManager
     conn.get(user_session_key(user_id))
   end
 
-  def self.clear(user_id)
+  def self.del(user_id)
     return unless active?
 
     conn.del(user_session_key(user_id))

--- a/lib/kracken/session_manager.rb
+++ b/lib/kracken/session_manager.rb
@@ -1,0 +1,31 @@
+class SessionManager
+  def self.conn
+    Redis.new(url: ENV["REDIS_SESSION_URL"])
+  end
+
+  def self.active?
+    ENV["REDIS_SESSION_URL"].present?
+  end
+
+  def self.get(user_id)
+    return unless active?
+
+    conn.get(user_session_key(user_id))
+  end
+
+  def self.clear(user_id)
+    return unless active?
+
+    conn.del(user_session_key(user_id))
+  end
+
+  def self.update(user_id, value)
+    return unless active?
+
+    conn.set(user_session_key(user_id), value)
+  end
+
+  def self.user_session_key(user_id)
+    "rnsession:#{user_id}"
+  end
+end

--- a/spec/kracken/controllers/authenticatable_spec.rb
+++ b/spec/kracken/controllers/authenticatable_spec.rb
@@ -137,6 +137,15 @@ module Kracken
         end
 
         context "user cache key" do
+          it "does nothing if the session does not exist" do
+            allow(controller).to receive(:request).and_return(double(format: nil, fullpath: nil))
+            allow(controller).to receive(:redirect_to)
+
+            controller.handle_user_cache_key!
+
+            expect(controller).to_not have_received(:redirect_to)
+          end
+
           it "ends session and redirects if stored key does not match session key" do
             controller.session[:user_cache_key] = "123"
             controller.session[:user_uid] = "123"


### PR DESCRIPTION
Partially addresses RadiusNetworks/Iris#1299

If an app includes this repo, and that app has an instance of Redis defined to track user sessions, these changes will check with Redis that the session is valid and hasn't been ended. This addresses an issue where a cookie may be reused maliciously, since although we clear cookies on logout, if the cookie has been retained it could be put into place elsewhere and still be valid.

Other PRs that will use this:
https://github.com/RadiusNetworks/kracken/pull/525
https://github.com/RadiusNetworks/iris/pull/1828