### PR TITLE
update faraday dependency to match oauth2 gem

### DIFF
--- a/kracken.gemspec
+++ b/kracken.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', [">= 5.2", "< 6.0"]
   s.add_dependency 'omniauth', '~> 1.0'
-  s.add_dependency 'faraday', '~> 0.8'
+  s.add_dependency 'faraday', ['>= 0.8', '< 2.0']
   s.add_dependency 'omniauth-oauth2', '~> 1.1'
 
   s.add_development_dependency 'rspec-rails', '~> 3.5'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'
-  s.add_development_dependency 'webmock'
+  s.add_development_dependency 'webmock', '~> 3.8'
 end

--- a/kracken.gemspec
+++ b/kracken.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |s|
   s.bindir      = "exe"
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
-  s.add_dependency 'rails', [">= 5.2", "< 6.0"]
-  s.add_dependency 'omniauth', '~> 1.0'
   s.add_dependency 'faraday', ['>= 0.8', '< 2.0']
+  s.add_dependency 'omniauth', '~> 1.0'
   s.add_dependency 'omniauth-oauth2', '~> 1.1'
+  s.add_dependency 'rails', [">= 5.2", "< 6.0"]
 
-  s.add_development_dependency 'rspec-rails', '~> 3.5'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'
+  s.add_development_dependency 'rspec-rails', '~> 3.5'
   s.add_development_dependency 'webmock', '~> 3.8'
 end

--- a/kracken.gemspec
+++ b/kracken.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday', ['>= 0.8', '< 2.0']
   s.add_dependency 'omniauth', '~> 1.0'
   s.add_dependency 'omniauth-oauth2', '~> 1.1'
-  s.add_dependency 'rails', [">= 5.2", "< 6.0"]
+  s.add_dependency 'rails', [">= 5.2", "< 7.0"]
 
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'

--- a/lib/kracken/rspec.rb
+++ b/lib/kracken/rspec.rb
@@ -46,6 +46,7 @@ end
 module Kracken
   module Controllers
     module Authenticatable
+      undef_method :current_user
       def current_user
         Kracken::SpecHelper.current_user
       end


### PR DESCRIPTION
This will allow projects that depend on this gem to have some flexibility to use a newer version of faraday.