### PR TITLE
fix travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,16 @@ bundler_args: --binstubs --jobs=3 --retry=3
 cache: bundler
 sudo: false
 before_install:
-  - gem i rubygems-update -v '<3' && update_rubygems
-  # from travis docs, to use bundler 1.x:
-  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install bundler -v '< 2'
+  - gem update --system
+  - gem install bundler
 before_script:
   - "bin/ci-code-review"
 script: bin/ci
 rvm:
-  - 2.5.0
+  - 2.6
+  - 2.7
 env:
   - RAILS_VERSION='~> 5.2.0'
   - RAILS_VERSION='5-2-stable'
 matrix:
-  include:
-    - rvm: 2.2.3
-      env: RAILS_VERSION='~> 5.2.0'
-    - rvm: 2.4.4
-      env: RAILS_VERSION='~> 4.2.10'
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,11 @@ rvm:
   - 2.5.0
 env:
   - RAILS_VERSION='~> 5.2.0'
-  - RAILS_VERSION='~> 5.1.0'
-  - RAILS_VERSION='5-1-stable'
   - RAILS_VERSION='5-2-stable'
 matrix:
   include:
     - rvm: 2.2.3
-      env: RAILS_VERSION='~> 5.1.0'
+      env: RAILS_VERSION='~> 5.2.0'
     - rvm: 2.4.4
       env: RAILS_VERSION='~> 4.2.10'
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ bundler_args: --binstubs --jobs=3 --retry=3
 cache: bundler
 sudo: false
 before_install:
-  - gem update --system
-  - gem install bundler
+  - gem i rubygems-update -v '<3' && update_rubygems
+  # from travis docs, to use bundler 1.x:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 before_script:
   - "bin/ci-code-review"
 script: bin/ci

--- a/bin/ci
+++ b/bin/ci
@@ -29,5 +29,5 @@ fi
 # Brakeman is a security scanner
 # https://github.com/presidentbeef/brakeman.
 echo " ---> Running breakman"
-gem install --no-rdoc --no-ri brakeman slim coffee-rails
+gem install brakeman slim coffee-rails
 brakeman --run-all-checks --exit-on-warn --ignore-config config/brakeman.ignore .

--- a/bin/ci
+++ b/bin/ci
@@ -29,5 +29,5 @@ fi
 # Brakeman is a security scanner
 # https://github.com/presidentbeef/brakeman.
 echo " ---> Running breakman"
-gem install brakeman slim coffee-rails
+gem install brakeman
 brakeman --run-all-checks --exit-on-warn --ignore-config config/brakeman.ignore .

--- a/kracken.gemspec
+++ b/kracken.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.bindir      = "exe"
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
-  s.add_dependency 'rails', [">= 4.0", "< 6.0"]
+  s.add_dependency 'rails', [">= 5.2", "< 6.0"]
   s.add_dependency 'omniauth', '~> 1.0'
   s.add_dependency 'faraday', '~> 0.8'
   s.add_dependency 'omniauth-oauth2', '~> 1.1'

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link_directory ../stylesheets .css
+//= link_directory ../javascripts .js


### PR DESCRIPTION
We were passing deprecated CLI params when trying to install brakeman. Also, sprockets now requires a manifest file for our dummy application.