### PR TITLE
Updates authentication check

### DIFF
--- a/lib/kracken/controllers/authenticatable.rb
+++ b/lib/kracken/controllers/authenticatable.rb
@@ -32,12 +32,13 @@ module Kracken
       end
 
       def authenticate_user
+        check_token_expiry!
         user_signed_in?
       end
 
       def authenticate_user!
-        check_token_expiry!
-        return if user_signed_in?
+        return if authenticate_user
+
         if request.format == :json
           render json: {error: '401 Unauthorized'}, status: :unauthorized
         elsif request.format == :js

--- a/spec/kracken/controllers/authenticatable_spec.rb
+++ b/spec/kracken/controllers/authenticatable_spec.rb
@@ -95,6 +95,7 @@ module Kracken
         end
 
         it "#authenticate_user is true" do
+          controller.session[:token_expires_at] = Time.zone.now + 5.minutes
           expect(controller.authenticate_user).to be_truthy
         end
 


### PR DESCRIPTION
Part one of #1818.

This change will let us use the `authenticate` method in Iris.

Connected PR (which will need a gem update to use this: https://github.com/RadiusNetworks/iris/pull/2049)