### PR TITLE
Allow host app to configure redis client options

### DIFF
--- a/kracken.gemspec
+++ b/kracken.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'omniauth', '~> 1.0'
   s.add_dependency 'omniauth-oauth2', '~> 1.1'
   s.add_dependency 'rails', [">= 5.2", "< 7.0"]
+  s.add_dependency 'redis'
 
-  s.add_development_dependency 'pry'
-  s.add_development_dependency 'pry-nav'
+  s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rspec-rails', '~> 3.5'
   s.add_development_dependency 'webmock', '~> 3.8'
 end

--- a/lib/kracken/config.rb
+++ b/lib/kracken/config.rb
@@ -3,7 +3,7 @@
 module Kracken
   class Config
     attr_accessor :app_id, :app_secret
-    attr_writer :provider_url
+    attr_writer :provider_url, :redis_options
 
     # @deprecated the associated reader returns static `::User`
     attr_writer :user_class
@@ -14,6 +14,10 @@ module Kracken
 
     def provider_url
       @provider_url ||= PROVIDER_URL
+    end
+
+    def redis_options
+      @redis_options ||= {}
     end
 
     def user_class

--- a/spec/kracken/config_spec.rb
+++ b/spec/kracken/config_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 module Kracken
   RSpec.describe Config do
 
-    subject(:config){ Kracken::Config.new }
+    subject(:config) { Kracken::Config.new }
 
     it "sets a default url" do
       expect(config.provider_url).to eq "https://account.radiusnetworks.com"
@@ -22,5 +22,18 @@ module Kracken
       expect(config.provider_url).to eq "http://joe.com"
     end
 
+    describe "#redis_options" do
+      it 'defaults to {}' do
+        expect(config.redis_options).to eq({})
+      end
+    end
+
+    describe "#redis_options=" do
+      it 'allows redis_options to be set' do
+        config.redis_options = { url: "redis://www.example.com" }
+
+        expect(config.redis_options).to eq({ url: "redis://www.example.com" })
+      end
+    end
   end
 end

--- a/spec/kracken/session_manager_spec.rb
+++ b/spec/kracken/session_manager_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Kracken
+  RSpec.describe SessionManager do
+    include Kracken::Spec::UsingEnv
+
+    describe "::conn" do
+      before { SessionManager.reset_conn }
+
+      context "when the REDIS_SESSION_URL env var is present" do
+        it 'is a Redis instance' do
+          using_env({ "REDIS_SESSION_URL" => "redis://www.example.com" }) do
+            expect(SessionManager.conn).to be_an_instance_of Redis
+          end
+        end
+      end
+
+      context "when the REDIS_SESSION_URL env var is not present" do
+        it 'is a NullRedis instance' do
+          expect(SessionManager.conn).to be_an_instance_of SessionManager::NullRedis
+        end
+      end
+    end
+  end
+end

--- a/spec/support/using_env.rb
+++ b/spec/support/using_env.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Kracken
+  module Spec
+    module UsingEnv
+      # By forcing the use of a block, this makes working within the context of
+      # a single spec much easier. If this needs to be wrapped around multiple
+      # specs, then an appropriate #around(:example) hook may be used.
+      #
+      # This is stolen with love from https://github.com/RadiusNetworks/captain/blob/master/spec/support/using_env.rb
+      #
+      # @param env_stubs [Hash{String => Object}]
+      #
+      # @yieldreturn
+      def using_env(env_stubs) # rubocop:disable Metrics/MethodLength
+        keys_to_delete = env_stubs.keys - ENV.keys
+        original_values = env_stubs.each_with_object({}) { |(k, v), env|
+          env[k] = ENV[k] if ENV.key?(k)
+          ENV[k] = v
+        }
+        yield
+      ensure
+        keys_to_delete.each do |k|
+          ENV.delete(k)
+        end
+        original_values.each do |k, v|
+          ENV[k] = v
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will allow us to provide the necessary SSL params in Kracken & Iris to disable SSL certificate verification, which we need to do to upgrade to Redis 6 on Heroku.