### PR TITLE
Lockdown 'oauth2' to version under 2

### DIFF
--- a/kracken.gemspec
+++ b/kracken.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday', ['>= 0.8', '< 2.0']
   s.add_dependency 'omniauth', '~> 1.0'
   s.add_dependency 'omniauth-oauth2', '~> 1.1'
+  s.add_dependency 'oauth2', '< 2'
   s.add_dependency 'rails', [">= 5.2", "< 7.0"]
   s.add_dependency 'redis'
 

--- a/lib/kracken/version.rb
+++ b/lib/kracken/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kracken
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
 end


### PR DESCRIPTION
Closes #50

Christopher S. and I were able to track down the error:

> OAuth2::Error - Could not find application:
> #<SnakyHash::StringKeyed error="Could not find application">:

The likely culprit is that the auth call is not including any identifying data. We didn't find more specific information about this, but the regression happens between v1.4.9 and >= v2.

We verified that locking down the "oauth2" gem to under 2 fixes the error. Later on, we'll probably need to address this issue when we want to use versions 2 and later.