### PR TITLE
Expand session info to include `is_admin` 

### DIFF
--- a/app/controllers/kracken/sessions_controller.rb
+++ b/app/controllers/kracken/sessions_controller.rb
@@ -8,6 +8,7 @@ module Kracken
       @user = user_class.find_or_create_from_auth_hash(auth_hash)
       session[:user_id] = @user.id
       session[:user_uid] = @user.uid
+      session[:is_admin] = @user.admin
       session[:user_cache_key] = Kracken::SessionManager.get(@user.uid)
       session[:token_expires_at] = Time.zone.at(auth_hash[:credentials][:expires_at])
 


### PR DESCRIPTION
We want to know if a logged in user in "iris" is admin without needing to look it up every time. This will, for now, be used when determining if we want to mount the karafka web-ui engine in the routes.