### PR TITLE
Ignore anything that isn't a URI path when returning

### DIFF
--- a/app/controllers/kracken/sessions_controller.rb
+++ b/app/controllers/kracken/sessions_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module Kracken
-  class SessionsController < ActionController::Base
+  class SessionsController < ActionController::Base # rubocop:disable Rails/ApplicationController
     protect_from_forgery with: :exception
 
-    def create
+    def create # rubocop:disable Metrics/AbcSize
       @user = user_class.find_or_create_from_auth_hash(auth_hash)
       session[:user_id] = @user.id
       session[:user_uid] = @user.uid
@@ -24,10 +24,12 @@ module Kracken
       render text: "Sorry, but you didn't allow access to our app!"
     end
 
-    protected
+  protected
 
     def return_to_path
-      request.env['omniauth.origin'] || "/"
+      return "/" unless request.env['omniauth.origin'].starts_with?('/')
+
+      request.env['omniauth.origin']
     end
 
     def auth_hash

--- a/lib/kracken/version.rb
+++ b/lib/kracken/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kracken
-  VERSION = "0.4.3"
+  VERSION = "0.4.4"
 end


### PR DESCRIPTION
Fix RadiusNetworks/moshi#543

We found that when passing the URI param `scope` to the `/auth/radius` URI, Omni Auth would redirect to the `scope` value. Cover 6 flagged this as a security issue.

This fix will simply ignore anything that is not a URI path and redirect back to `"/"`.