### PR TITLE
Reject protocol-relative URLs in return_to_path to fix open redirect

### DIFF
--- a/app/controllers/kracken/sessions_controller.rb
+++ b/app/controllers/kracken/sessions_controller.rb
@@ -27,9 +27,12 @@ module Kracken
   protected
 
     def return_to_path
-      return "/" unless request.env['omniauth.origin'].starts_with?('/')
-
-      request.env['omniauth.origin']
+      origin = request.env['omniauth.origin']
+      return "/" unless origin&.start_with?('/')
+      return "/" if URI.parse(origin).host
+      origin
+    rescue URI::InvalidURIError
+      "/"
     end
 
     def auth_hash

--- a/spec/kracken/sessions_controller_spec.rb
+++ b/spec/kracken/sessions_controller_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Kracken::SessionsController, type: :controller do
+  routes { Kracken::Engine.routes }
+
+  let(:auth_hash) { OmniAuth::AuthHash.new(Kracken::Fixtures.auth_hash) }
+  let(:user_double) { double(:user, id: "1", uid: "1", admin: false) }
+
+  before do
+    allow(User).to receive(:find_or_create_from_auth_hash).and_return(user_double)
+    allow(Kracken::SessionManager).to receive(:get).and_return(nil)
+    request.env['omniauth.auth'] = auth_hash
+  end
+
+  describe "GET :create" do
+    context "with a safe relative origin" do
+      it "redirects to the origin path" do
+        request.env['omniauth.origin'] = '/admin/projects/1'
+        get :create, params: { provider: 'radius' }
+        expect(response).to redirect_to('/admin/projects/1')
+      end
+
+      it "redirects to root when origin is '/'" do
+        request.env['omniauth.origin'] = '/'
+        get :create, params: { provider: 'radius' }
+        expect(response).to redirect_to('/')
+      end
+    end
+
+    context "with a protocol-relative URL" do
+      it "redirects to root for //yahoo.com" do
+        request.env['omniauth.origin'] = '//yahoo.com'
+        get :create, params: { provider: 'radius' }
+        expect(response).to redirect_to('/')
+      end
+
+      it "redirects to root for //yahoo.com/path" do
+        request.env['omniauth.origin'] = '//yahoo.com/path'
+        get :create, params: { provider: 'radius' }
+        expect(response).to redirect_to('/')
+      end
+    end
+
+    context "with an absolute URL" do
+      it "redirects to root" do
+        request.env['omniauth.origin'] = 'https://yahoo.com'
+        get :create, params: { provider: 'radius' }
+        expect(response).to redirect_to('/')
+      end
+    end
+
+    context "with no origin" do
+      it "redirects to root" do
+        request.env['omniauth.origin'] = nil
+        get :create, params: { provider: 'radius' }
+        expect(response).to redirect_to('/')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes RadiusNetworks/moshi#892

## Summary
- Fixes a bypass of the previous open redirect fix (PR #53 / kracken v0.4.4) where protocol-relative URLs like `//yahoo.com` passed the `starts_with?('/')` check but still redirected off-domain
- `return_to_path` now uses `URI.parse` to reject any origin carrying a host component, falling back to `/` for invalid URIs
- Adds a new `SessionsController` spec covering safe relative paths, protocol-relative URLs, absolute URLs, and nil origin

## Test plan
- [ ] `bundle exec rspec spec/kracken/sessions_controller_spec.rb` — all 6 new examples pass
- [ ] `bundle exec rspec` — no regressions in existing suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)